### PR TITLE
docs: Add CODE_OF_CONDUCT.md and CONTRIBUTING.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+https://github.com/Scottcjn.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to llama.cpp for IBM POWER8
+
+Thank you for your interest in contributing to llama.cpp for POWER8! This document provides guidelines and instructions for contributing.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [How Can I Contribute?](#how-can-i-contribute)
+- [Development Setup](#development-setup)
+- [Building](#building)
+- [Pull Request Process](#pull-request-process)
+- [Style Guidelines](#style-guidelines)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) code of conduct. By participating, this project, you agree to uphold this code. Please report unacceptable behavior to the repository maintainers.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+Before creating bug reports, please check the issue list. When creating a bug report, include:
+
+- **Clear title and description**
+- **Steps to reproduce**
+- **Expected vs actual behavior**
+- **Environment details** (OS, POWER8 model, memory)
+- **Build configuration** (cmake flags, compiler version)
+
+### Suggesting Enhancements
+
+- Check if the enhancement has been suggested
+- Describe the feature and its benefits
+- Explain how it fits with POWER8 optimization goals
+
+### Pull Requests
+
+- Fork the repository
+- Create a feature branch
+- Make your changes
+- Add tests if applicable
+- Submit a pull request
+
+## Development Setup
+
+### Prerequisites
+
+- IBM POWER8 system or simulator
+- GCC 11+ or Clang 14+
+- CMake 3.14+
+- Git
+
+### Setup Steps
+
+1. Fork and clone:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/llama-cpp-power8.git
+   cd llama-cpp-power8
+   ```
+
+2. Create build directory:
+   ```bash
+   mkdir build && cd build
+   ```
+
+3. Configure with cmake:
+   ```bash
+   cmake .. -DCMAKE_BUILD_TYPE=Release
+   ```
+
+4. Build:
+   ```bash
+   cmake --build . --config Release -j 8
+   ```
+
+## Building
+
+### POWER8 Optimizations
+
+This port includes POWER8-specific optimizations:
+
+- **POWER9 intrinsics** via `power8-compat.h`
+- **DCBT prefetch hints** via `ggml-dcbt-resident.h`
+- **AltiVec/VSX** vectorization support
+
+### Build Flags
+
+```bash
+# Enable POWER8 optimizations (default: ON)
+cmake .. -DGGML_POWER8=ON
+
+# Enable AltiVec/VSX (default: ON)
+cmake .. -DGGML_ALTIVEC=ON
+
+# Enable native instructions
+cmake .. -DGGML_NATIVE=ON
+```
+
+## Pull Request Process
+
+1. **Branch naming**: Use descriptive names like `feature/add-power9-intrinsics` or `fix/dcbt-hint`
+2. **Commit messages**: Follow conventional commits format
+3. **Testing**: Include performance benchmarks for changes
+4. **Documentation**: Update README as needed
+5. **Review**: Address all review comments
+
+## Style Guidelines
+
+### C Code Style
+
+- Follow existing formatting in the file
+- Use 4 spaces for indentation
+- Keep lines under 120 characters
+- Add comments for complex POWER8-specific code
+
+### Commit Messages
+
+- Use the present tense ("Add feature" not "Added feature")
+- Use the imperative mood ("Optimize..." not "Optimizes...")
+- Reference issues and pull requests
+
+### Performance Testing
+
+When contributing performance optimizations:
+
+1. Include benchmark results
+2. Compare against baseline
+3. Test on real POWER8 hardware when possible
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.
+
+---
+
+🤝 Generated for the POWER8 community


### PR DESCRIPTION
## Summary

This PR adds community documentation files for the llama.cpp POWER8 port.

## Changes

- ✅ CODE_OF_CONDUCT.md - Contributor Covenant v2.0
- ✅ CONTRIBUTING.md with:
  - Development setup instructions
  - POWER8-specific build flags
  - Pull request process
  - Style guidelines

Closes #3
Closes #4

🤖 Generated by Claw (AI Agent)